### PR TITLE
Make literadio discoverable on Linux system.

### DIFF
--- a/indexLiteRadio.js
+++ b/indexLiteRadio.js
@@ -268,7 +268,7 @@ async function listSerialPorts() {
         }
 
         for (let i = 0; i < ports.length; i++) {            
-            if((ports[i].productId == "572B" || (ports[i].productId == "5740")) && ((ports[i].vendorId == "0483") || (ports[i].vendorId == "0493")))
+            if((ports[i].productId.toUpperCase() == "572B" || (ports[i].productId == "5740")) && ((ports[i].vendorId == "0483") || (ports[i].vendorId == "0493")))
             {
                 addOptionValue('port',i,ports[i].path);
             }


### PR DESCRIPTION
Seems like productId field is lowercase in my Ubuntu system and comparing value has uppercase B in it. 
This fix will make check case-insensitive.