### PR TITLE
📝 Typo and incorrect word fixes

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3050,7 +3050,7 @@
         "message": "Warning"
     }, 
     "firmwareFlasherSteps": {
-        "message": "Stpes of how to flasher"
+        "message": "Steps of how to flash"
     },
     "firmwareInfo": {
         "message": "Firmware Info"


### PR DESCRIPTION
These to micro-mistakes where fixed in English translation
- `Stpes` -> `steps` (typo)
- `flasher` -> `flash` (the first word is related to the firmware **updater itself**, while the second one is related to firmware **update process**)